### PR TITLE
[R4R]Fast Finality: change vote data struct

### DIFF
--- a/consensus/consensus.go
+++ b/consensus/consensus.go
@@ -150,6 +150,7 @@ type PoSA interface {
 	IsLocalBlock(header *types.Header) bool
 	AllowLightProcess(chain ChainReader, currentHeader *types.Header) bool
 	// VerifyVote will verify if the vote comes from valid validators based on voteAddress (BLSPublicKey).
+	GetHighestJustifiedHeader(chain ChainReader, header *types.Header) *types.Header
 	VerifyVote(chain ChainHeaderReader, vote *types.VoteEnvelope) bool
 	SetVotePool(votePool VotePool)
 }

--- a/consensus/parlia/parlia.go
+++ b/consensus/parlia/parlia.go
@@ -686,8 +686,8 @@ func (p *Parlia) PrepareVoteAttestation(chain consensus.ChainHeaderReader, heade
 			if len(votes) > len(snap.Validators)*3/4 {
 				attestation := &types.VoteAttestation{
 					Data: &types.VoteData{
-						BlockNumber: parent.Number.Uint64(),
-						BlockHash:   parent.Hash(),
+						TargetNumber: parent.Number.Uint64(),
+						TargetHash:   parent.Hash(),
 					},
 				}
 				// Prepare aggregated vote signature.
@@ -831,7 +831,7 @@ func (p *Parlia) distributeFinalityReward(chain consensus.ChainHeaderReader, sta
 		if voteAttestation == nil {
 			continue
 		}
-		justifiedBlock := chain.GetHeaderByHash(voteAttestation.Data.BlockHash)
+		justifiedBlock := chain.GetHeaderByHash(voteAttestation.Data.TargetHash)
 		if justifiedBlock == nil {
 			continue
 		}
@@ -1019,8 +1019,8 @@ func (p *Parlia) FinalizeAndAssemble(chain consensus.ChainHeaderReader, header *
 
 // VerifyVote will verify if the vote comes from valid validators.
 func (p *Parlia) VerifyVote(chain consensus.ChainHeaderReader, vote *types.VoteEnvelope) bool {
-	voteBlockNumber := vote.Data.BlockNumber
-	voteBlockHash := vote.Data.BlockHash
+	voteBlockNumber := vote.Data.TargetNumber
+	voteBlockHash := vote.Data.TargetHash
 	header := chain.GetHeader(voteBlockHash, voteBlockNumber)
 	if header == nil {
 		log.Error("BlockHeader at current voteBlockNumber is nil", "blockNumber=", voteBlockNumber, "blockHash=", voteBlockHash)
@@ -1494,6 +1494,10 @@ func (p *Parlia) applyTransaction(
 	receipt.TransactionIndex = uint(state.TxIndex())
 	*receipts = append(*receipts, receipt)
 	state.SetNonce(msg.From(), nonce+1)
+	return nil
+}
+
+func (p *Parlia) GetHighestJustifiedHeader(chain consensus.ChainReader, header *types.Header) *types.Header {
 	return nil
 }
 

--- a/consensus/parlia/snapshot.go
+++ b/consensus/parlia/snapshot.go
@@ -154,8 +154,8 @@ func (s *Snapshot) copy() *Snapshot {
 	}
 	if s.Attestation != nil {
 		cpy.Attestation = &types.VoteData{
-			BlockNumber: s.Attestation.BlockNumber,
-			BlockHash:   s.Attestation.BlockHash,
+			TargetNumber: s.Attestation.TargetNumber,
+			TargetHash:   s.Attestation.TargetHash,
 		}
 	}
 	return cpy

--- a/core/types/vote.go
+++ b/core/types/vote.go
@@ -16,8 +16,10 @@ type BLSSignature [BLSSignatureLength]byte
 type ValidatorsBitSet uint64
 
 type VoteData struct {
-	BlockNumber uint64
-	BlockHash   common.Hash
+	SourceNumber uint64
+	SourceHash   common.Hash
+	TargetNumber uint64
+	TargetHash   common.Hash
 }
 
 type VoteEnvelope struct {
@@ -58,16 +60,7 @@ func (v *VoteEnvelope) calcVoteHash() common.Hash {
 
 // VoteDataHash returns the voteData hash.
 func (v *VoteData) VoteDataHash() common.Hash {
-	h := v.calcVoteDataHash()
-	return h
-}
-
-func (v *VoteData) calcVoteDataHash() common.Hash {
-	voteData := struct {
-		BlockNumber uint64
-		BlockHash   common.Hash
-	}{v.BlockNumber, v.BlockHash}
-	return rlpHash(voteData)
+	return rlpHash(*v)
 }
 
 func (b BLSPublicKey) Bytes() []byte { return b[:] }

--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -1086,8 +1086,8 @@ func (c *finalitySignatureVerify) Run(input []byte) ([]byte, error) {
 	pubKeys[0] = pubKey
 	pubKeys[1] = pubKey
 
-	msgs[0] = rlpHash(types.VoteData{BlockNumber: numA, BlockHash: common.BytesToHash(headerA)})
-	msgs[1] = rlpHash(types.VoteData{BlockNumber: numB, BlockHash: common.BytesToHash(headerB)})
+	msgs[0] = rlpHash(types.VoteData{TargetNumber: numA, TargetHash: common.BytesToHash(headerA)})
+	msgs[1] = rlpHash(types.VoteData{TargetNumber: numB, TargetHash: common.BytesToHash(headerB)})
 	sigs[0] = sigA
 	sigs[1] = sigB
 

--- a/core/vote/vote_pool_test.go
+++ b/core/vote/vote_pool_test.go
@@ -74,7 +74,7 @@ func (journal *VoteJournal) verifyJournal(size, lastLatestVoteNumber int) bool {
 		time.Sleep(1 * time.Second)
 		lastIndex, _ := journal.walLog.LastIndex()
 		firstIndex, _ := journal.walLog.FirstIndex()
-		if journal.latestVote.Data.BlockNumber == uint64(lastLatestVoteNumber) && int(lastIndex)-int(firstIndex)+1 == size {
+		if journal.latestVote.Data.TargetNumber == uint64(lastLatestVoteNumber) && int(lastIndex)-int(firstIndex)+1 == size {
 			return true
 		}
 	}
@@ -171,7 +171,7 @@ func TestVotePool(t *testing.T) {
 	// Test invalid vote whose number larger than latestHeader + 11
 	invalidVote := &types.VoteEnvelope{
 		Data: &types.VoteData{
-			BlockNumber: 1000,
+			TargetNumber: 1000,
 		},
 	}
 	voteManager.pool.PutVote(invalidVote)
@@ -193,7 +193,7 @@ func TestVotePool(t *testing.T) {
 	// Test future votes scenario: votes number within latestBlockHeader ~ latestBlockHeader + 11
 	futureVote := &types.VoteEnvelope{
 		Data: &types.VoteData{
-			BlockNumber: 282,
+			TargetNumber: 282,
 		},
 	}
 	voteManager.pool.PutVote(futureVote)
@@ -210,7 +210,7 @@ func TestVotePool(t *testing.T) {
 	// Test duplicate vote case, shouldn'd be put into vote pool
 	duplicateVote := &types.VoteEnvelope{
 		Data: &types.VoteData{
-			BlockNumber: 282,
+			TargetNumber: 282,
 		},
 	}
 	voteManager.pool.PutVote(duplicateVote)
@@ -227,7 +227,7 @@ func TestVotePool(t *testing.T) {
 	// Test future votes larger than latestBlockNumber + 11 should be rejected
 	futureVote = &types.VoteEnvelope{
 		Data: &types.VoteData{
-			BlockNumber: 285,
+			TargetNumber: 285,
 		},
 	}
 	voteManager.pool.PutVote(futureVote)

--- a/eth/handler_eth_test.go
+++ b/eth/handler_eth_test.go
@@ -894,8 +894,8 @@ func testSendVotes(t *testing.T, protocol uint) {
 			VoteAddress: types.BLSPublicKey{},
 			Signature:   types.BLSSignature{},
 			Data: &types.VoteData{
-				BlockNumber: uint64(index),
-				BlockHash:   common.BytesToHash(common.Hex2Bytes(string(rune(index)))),
+				TargetNumber: uint64(index),
+				TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(index)))),
 			},
 		}
 		insert[index] = &vote
@@ -999,8 +999,8 @@ func testRecvVotes(t *testing.T, protocol uint) {
 	// Send the vote to the sink and verify that it's added to the vote pool
 	vote := types.VoteEnvelope{
 		Data: &types.VoteData{
-			BlockNumber: uint64(1),
-			BlockHash:   common.BytesToHash(common.Hex2Bytes(string(rune(1)))),
+			TargetNumber: uint64(1),
+			TargetHash:   common.BytesToHash(common.Hex2Bytes(string(rune(1)))),
 		},
 	}
 


### PR DESCRIPTION
## Summary
This PR tries to implement fast finality mechanism introduced by [BEP-126](https://github.com/bnb-chain/BEPs/pull/126). 

## Abstract
BEP-126 Proposal describes a fast finality mechanism to finalize a block, once the block has been finalized, it won't be
reverted forever.

It takes several steps to finalize a block:
1. A block is proposed by a validator and propagated to other validators.
2. Validators use their BLS private key to sign for the block as a vote message.
3. Gather the votes from validators into a pool.
4. Aggregate the BLS signature if a block has gotten enough votes from validators as an attestation.
5. Set the vote attestation into the extra field of the header while proposing a child block.
6. Validators and full nodes who received the child block with the block's attestation can justify the block.
7. The previous latest justified block then get finalized.

The finality of a block can be achieved within two blocks in most cases, this is expected to reduce the chance
of chain re-organization and stabilize the block producing further.

## Motivation
Finality is critical for blockchain security, once the block is finalized, it would not be reverted anymore. The fast
finality feature is very useful, users can make sure they get the accurate information from the latest finalized block,
then they can decide what to do next instantly.

Currently, on BNB Smart chain, all the full nodes and validators need wait until enough blocks have been produced
to ensure a probabilistic finality. For BSC, with 21 validators, full nodes and validators can wait 1/2*21+1=11 blocks
to ensure a relatively secure finality, it would be quite long time for some critical applications.

## Specification
The vote message is signed by validators’ private key through the BLS algorithm, however the BLS private and public keys are different from traditional wallet account’s private and public keys, so use a new key manager to manage BLS related keys. 

In order to collect the vote information, we use another votepool to gather the votes from validators, this votepool is similar to txpool but independent. 

Validators can vote for blocks they received under the above two rules. Once the votes in the votepool are more than ¾+ validators, the validator  will aggregate the votes message and write them to the proposed block’s header when it proposes new blocks.

The block receivers, either full nodes or non-proposer validators, download the block from p2p node, verify the votes from valid validators and verify the BLS aggregated signature if exist, also reject the block older than finalized block, insert the block into the blockchain, write the new attestation info to the consensus snapshot, distribute reward in finalize function if reward requirements meet, and update chain level finality info. 

The slash related function is implemented in a stand alone slash contract, anyone can get a vote message from votepool, once they find the malicious behavior, they can submit the assembled evidence to slash contract, and slash contract will do the detailed verification and slash actions. The evidence format, verification procedure and slash actions will be designed in slash component design.

### BLS and BLS Key Manager
BLS is used to sign the vote for fast finality, aggregate the votes from different validators, verify the signature from different validators and verify the aggregated signatures. Since the BLS private key and public key are different from current Ethereum accounts’ key, we introduce another key manager to manage the BLS private key and public key.
Besides, in order to format the sign data, we sign the hash of the sign data not the data itself.

### Vote Pool
The votepool is used to gather votes from different validators, propagating votes to other nodes. All active validators can vote for the fast finality of blocks under the two rules described in BEP-126, the vote data should at least include **{BlockNumber, BlockHash}**.  Validators use their BLS private key to sign the hash of **{BlockNumber, BlockHash}**, so the vote message is **{BLSPubKey, {BlockNumber, BlockHash}, Signature}**, once the receivers see the vote message, they can verify it easily.

As we know propagating messages is the duty of P2P protocols, in order to propagate the vote message, we will define new message types based on current ETH67 protocol.

In order to finalize blocks, the miner should assemble the vote messages for the latest unfinalized block once its valid votes more than ¾ validators, and write them to the block header as an attestation. The assembled signature should be **{ValidatorsIndexBitmap, {BlockNumber, BlockHash}, AggregatedSignature}**, the bitmap indicates the validators that voted for the block, aggregate their vote signatures into aggregated signature, the aggregated signature is the same length with each common signature.

Once the validators or full nodes receive a block, they should verify the block header, for the fast finality, they should verify the assembled attestation information. As the consensus engine can get validators’ information from the snapshot, the BLS public key should be recorded as a part of validator, through the ValidatorsIndexBitmap we can easily get their BLS public keys, then we can use the BLS FastAggregateVerify function to verify the aggregated signature.

### Reward
Distributing reward should be a part of the consensus engine, in order to make the consensus lighter, we would distribute the reward by batch, once an epoch. As the attestation informations has been recorded in the headers, so we can iterate the headers from the first block to the last block of the previous epoch, find out the attestation and which validators have voted for them, and we can also get the distance between the attested block and the block’s header which records the attestation information, then we can compute the distribute weight.

Through the iteration, we can get two arrays {validators[], accumulatedWeights[]}, then call the distributeFinalityReward method of ValidatorSet contract and pass these two parameters.

The total reward for validators of this epoch would be a part balance of the SystemReward contract, the partial would be set to 10% initially and can be governed. Once we get the total reward, then distribute the total reward to each validator by the accumulatedWeights.

### Slash
Anyone can get validators’ vote message from vote pool, if they find some validators’ vote message violate one of the rules described in BEP-126, they can assemble the evidence and submit to the slash contract, slash contract will verify the submitted evidence, once the evidence has been verified, the malicious validator will be slashed and the submitter will be rewarded. 